### PR TITLE
Add scroll-triggered animations across landing page

### DIFF
--- a/src/app/Components/SplitText.tsx
+++ b/src/app/Components/SplitText.tsx
@@ -20,6 +20,7 @@ export interface SplitTextProps {
   tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
   textAlign?: React.CSSProperties["textAlign"];
   onLetterAnimationComplete?: () => void;
+  once?: boolean;
 }
 
 const SplitText: React.FC<SplitTextProps> = ({
@@ -36,6 +37,7 @@ const SplitText: React.FC<SplitTextProps> = ({
   tag = "p",
   textAlign = "center",
   onLetterAnimationComplete,
+  once = true,
 }) => {
   const ref = useRef<HTMLParagraphElement>(null);
   const animationCompletedRef = useRef(false);
@@ -99,6 +101,19 @@ const SplitText: React.FC<SplitTextProps> = ({
         reduceWhiteSpace: false,
         onSplit: (self: GSAPSplitText) => {
           assignTargets(self);
+          const triggerConfig: ScrollTrigger.Vars = {
+            trigger: el,
+            start,
+            fastScrollEnd: true,
+            anticipatePin: 0.4,
+          };
+
+          if (once) {
+            triggerConfig.once = true;
+          } else {
+            triggerConfig.toggleActions = "play none none reverse";
+          }
+
           return gsap.fromTo(
             targets,
             { ...from },
@@ -107,13 +122,7 @@ const SplitText: React.FC<SplitTextProps> = ({
               duration,
               ease,
               stagger: delay / 1000,
-              scrollTrigger: {
-                trigger: el,
-                start,
-                once: true,
-                fastScrollEnd: true,
-                anticipatePin: 0.4,
-              },
+              scrollTrigger: triggerConfig,
               onComplete: () => {
                 animationCompletedRef.current = true;
                 onLetterAnimationComplete?.();
@@ -148,6 +157,7 @@ const SplitText: React.FC<SplitTextProps> = ({
         rootMargin,
         fontsLoaded,
         onLetterAnimationComplete,
+        once,
       ],
       scope: ref,
     }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,6 +135,85 @@ body {
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+[data-animate="category-card"] {
+  position: relative;
+  overflow: hidden;
+  --category-shine: 0;
+}
+
+[data-animate="category-card"]::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.2) 0%,
+    rgba(255, 255, 255, 0) 65%
+  );
+  opacity: calc(0.25 + var(--category-shine) * 0.35);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+[data-animate="category-card"]::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  background: radial-gradient(
+      120% 180% at 0% 100%,
+      rgba(255, 255, 255, 0.55),
+      rgba(255, 255, 255, 0) 70%
+    ),
+    linear-gradient(
+      110deg,
+      rgba(255, 255, 255, 0.32) 0%,
+      rgba(255, 255, 255, 0) 55%
+    );
+  opacity: calc(var(--category-shine) * 0.75);
+  transform: translateX(calc((var(--category-shine) - 1) * 35%));
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+[data-animate="sketch-card"] {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  --sketch-progress: 0;
+}
+
+[data-animate="sketch-card"]::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  border: 2px dashed rgba(59, 130, 246, 0.25);
+  opacity: calc(0.15 + var(--sketch-progress) * 0.45);
+  transform-origin: left center;
+  transform: scaleX(calc(0.3 + var(--sketch-progress) * 0.7));
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+[data-animate="sketch-card"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    120deg,
+    rgba(255, 255, 255, 0.28) 0px,
+    rgba(255, 255, 255, 0.28) 12px,
+    transparent 12px,
+    transparent 24px
+  );
+  opacity: calc(0.1 + var(--sketch-progress) * 0.35);
+  transform-origin: left center;
+  transform: scaleX(calc(0.05 + var(--sketch-progress) * 0.95));
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -252,6 +252,28 @@ export default function Home() {
           );
       });
 
+      const popElements = gsap.utils.toArray<HTMLElement>(
+        q("[data-animate='pop']")
+      );
+      popElements.forEach((element) => {
+        gsap.fromTo(
+          element,
+          { opacity: 0, y: 70, scale: 0.86 },
+          {
+            opacity: 1,
+            y: 0,
+            scale: 1,
+            duration: 0.85,
+            ease: "expo.out",
+            scrollTrigger: {
+              trigger: element,
+              start: "top 85%",
+              toggleActions: "play none none reverse",
+            },
+          }
+        );
+      });
+
       const featureSection = q("[data-animate='feature-section']")[0] as
         | HTMLElement
         | undefined;
@@ -263,12 +285,6 @@ export default function Home() {
         );
 
         if (featureHeaders.length) {
-          const headerOffsets: Array<gsap.TweenVars> = [
-            { x: -90 },
-            { y: 70 },
-            { x: 90 },
-          ];
-
           const featureTimeline = gsap.timeline({
             scrollTrigger: {
               trigger: featureSection,
@@ -278,13 +294,13 @@ export default function Home() {
           });
 
           featureHeaders.forEach((header, idx) => {
-            const baseFrom = headerOffsets[idx] ?? { y: 50 };
             featureTimeline.fromTo(
               header,
-              { ...baseFrom, opacity: 0 },
+              { y: 70, opacity: 0, scale: 0.86 },
               {
                 x: 0,
                 y: 0,
+                scale: 1,
                 opacity: 1,
                 duration: 0.75,
                 ease: "power3.out",
@@ -315,15 +331,21 @@ export default function Home() {
           .fromTo(
             card,
             {
-              clipPath: "polygon(0 0, 0 0, 0 100%, 0 100%)",
+              opacity: 0,
+              y: 90,
+              scale: 0.84,
+              rotateX: 12,
               "--sketch-progress": 0,
               boxShadow: "0px 0px 0px rgba(15, 23, 42, 0)",
             },
             {
-              clipPath: "polygon(0 0, 100% 0, 100% 100%, 0 100%)",
+              opacity: 1,
+              y: 0,
+              scale: 1,
+              rotateX: 0,
               "--sketch-progress": 1,
-              duration: 1,
-              ease: "power2.out",
+              duration: 0.9,
+              ease: "expo.out",
               boxShadow: "0px 25px 45px rgba(15, 23, 42, 0.18)",
             }
           )
@@ -349,10 +371,11 @@ export default function Home() {
         if (whyLines.length) {
           gsap.fromTo(
             whyLines,
-            { x: -120, opacity: 0 },
+            { y: 70, opacity: 0, scale: 0.86 },
             {
-              x: 0,
+              y: 0,
               opacity: 1,
+              scale: 1,
               duration: 0.8,
               ease: "power3.out",
               stagger: 0.2,
@@ -399,10 +422,11 @@ export default function Home() {
         if (teamHeaders.length) {
           gsap.fromTo(
             teamHeaders,
-            { y: 70, opacity: 0 },
+            { y: 70, opacity: 0, scale: 0.86 },
             {
               y: 0,
               opacity: 1,
+              scale: 1,
               duration: 0.75,
               ease: "power3.out",
               stagger: 0.18,
@@ -514,10 +538,13 @@ export default function Home() {
 
           <div>
           <div className="sticky bg-white top-0 z-[99] py-15 animate-fade-up animate-ease-in-out px-10">
-            <p className="text-center font-bold text-3xl lg:text-5xl">
+            <p
+              data-animate="pop"
+              className="text-center font-bold text-3xl lg:text-5xl"
+            >
               Find and Share Your Destinations
             </p>
-            <p className="text-center mt-3 text-gray-600">
+            <p data-animate="pop" className="text-center mt-3 text-gray-600">
               A few taps, know where to go on the map; find extraordinary places
               in Hong Kong.
             </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,21 +3,18 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import dynamicImport from "next/dynamic";
-import Image from "next/image";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { createClient } from "@supabase/supabase-js";
 import CameraCapture from "./Components/Camera";
 import Chat from "./Components/Chat";
 import Ranking from "./Components/Ranking";
-import Translate from "./Components/Translate";
 import Beams from "@/components/Beams";
 
 import Dock from "./Components/Dock";
-import { tr } from "motion/react-client";
-import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import SplitText from "./Components/SplitText";
-import SpotlightCard from "./Components/SpotlightCard";
+import { gsap } from "gsap";
+import { useGSAP } from "@gsap/react";
 
 const Map = dynamicImport(() => import("./Components/Map"), {
   ssr: false,
@@ -49,6 +46,8 @@ export default function Home() {
   const [topCategories, setTopCategories] = useState<any[]>([]);
 
   const [search, setSearch] = useState("");
+
+  const pageRef = useRef<HTMLDivElement>(null);
 
   const handleAnimationComplete = () => {
     console.log("All letters have animated!");
@@ -198,42 +197,216 @@ export default function Home() {
     return score;
   }
 
+  useGSAP(
+    () => {
+      const q = gsap.utils.selector(pageRef);
+
+      const categoryCards = q("[data-animate='category-card']") as HTMLElement[];
+      categoryCards.forEach((card, index) => {
+        gsap.fromTo(
+          card,
+          { opacity: 0, y: 60, scale: 0.9, transformOrigin: "center bottom" },
+          {
+            opacity: 1,
+            y: 0,
+            scale: 1,
+            duration: 0.8,
+            ease: "back.out(1.6)",
+            delay: index * 0.08,
+            scrollTrigger: {
+              trigger: card,
+              start: "top 85%",
+              toggleActions: "play none none reverse",
+            },
+          }
+        );
+      });
+
+      const featureSection = q("[data-animate='feature-section']")[0] as
+        | HTMLElement
+        | undefined;
+      if (featureSection) {
+        const featureHeaders = Array.from(
+          featureSection.querySelectorAll<HTMLElement>(
+            "[data-animate='feature-header']"
+          )
+        );
+
+        if (featureHeaders.length) {
+          gsap.fromTo(
+            featureHeaders,
+            { y: 50, opacity: 0 },
+            {
+              y: 0,
+              opacity: 1,
+              duration: 0.7,
+              ease: "power3.out",
+              stagger: 0.18,
+              scrollTrigger: {
+                trigger: featureSection,
+                start: "top 80%",
+                toggleActions: "play none none reverse",
+              },
+            }
+          );
+        }
+      }
+
+      const sketchCards = q("[data-animate='sketch-card']") as HTMLElement[];
+      sketchCards.forEach((card) => {
+        gsap.fromTo(
+          card,
+          { clipPath: "inset(0 100% 0 0)", opacity: 0 },
+          {
+            clipPath: "inset(0 0% 0 0)",
+            opacity: 1,
+            duration: 1.2,
+            ease: "power2.out",
+            scrollTrigger: {
+              trigger: card,
+              start: "top 85%",
+              toggleActions: "play none none reverse",
+            },
+          }
+        );
+      });
+
+      const whyText = q("[data-animate='why-text']")[0] as HTMLElement | undefined;
+      if (whyText) {
+        gsap.fromTo(
+          whyText,
+          { x: -120, opacity: 0 },
+          {
+            x: 0,
+            opacity: 1,
+            duration: 0.8,
+            ease: "power3.out",
+            scrollTrigger: {
+              trigger: whyText,
+              start: "top 80%",
+              toggleActions: "play none none reverse",
+            },
+          }
+        );
+      }
+
+      const teamSection = q("[data-animate='team-section']")[0] as
+        | HTMLElement
+        | undefined;
+      if (teamSection) {
+        const teamHeaders = Array.from(
+          teamSection.querySelectorAll<HTMLElement>(
+            "[data-animate='team-header']"
+          )
+        );
+
+        if (teamHeaders.length) {
+          gsap.fromTo(
+            teamHeaders,
+            { y: 60, opacity: 0 },
+            {
+              y: 0,
+              opacity: 1,
+              duration: 0.75,
+              ease: "power3.out",
+              stagger: 0.18,
+              scrollTrigger: {
+                trigger: teamSection,
+                start: "top 80%",
+                toggleActions: "play none none reverse",
+              },
+            }
+          );
+        }
+      }
+
+      const teamCards = q("[data-animate='team-card']") as HTMLElement[];
+      teamCards.forEach((card, index) => {
+        gsap.fromTo(
+          card,
+          { y: 90, opacity: 0, scale: 0.92, rotate: -4 },
+          {
+            y: 0,
+            opacity: 1,
+            scale: 1,
+            rotate: 0,
+            duration: 0.85,
+            ease: "power3.out",
+            delay: index * 0.05,
+            scrollTrigger: {
+              trigger: card,
+              start: "top 85%",
+              toggleActions: "play none none reverse",
+            },
+          }
+        );
+      });
+
+      const ideasButton = q("[data-animate='ideas-button']")[0] as
+        | HTMLElement
+        | undefined;
+      if (ideasButton) {
+        gsap.fromTo(
+          ideasButton,
+          { opacity: 0, y: 50 },
+          {
+            opacity: 1,
+            y: 0,
+            duration: 0.6,
+            ease: "power3.out",
+            scrollTrigger: {
+              trigger: ideasButton,
+              start: "top 85%",
+              toggleActions: "play none none reverse",
+            },
+          }
+        );
+      }
+    },
+    {
+      scope: pageRef,
+      dependencies: [topCategories.length],
+      revertOnUpdate: true,
+    }
+  );
+
   return (
     <>
       <Suspense fallback={<div>Loading...</div>}>
-        <div
-          className={
-            selectedCategory == "default" ? "hidden" : "flex justify-center"
-          }
-        >
+        <div ref={pageRef}>
           <div
-            onClick={() => {
-              window.location.replace(`/`);
-            }}
-            className="fixed top-5 p-1 px-3 z-[100] bg-indigo-500 cursor-pointer rounded-full"
+            className={
+              selectedCategory == "default" ? "hidden" : "flex justify-center"
+            }
           >
-            <p className="text-white text-sm text-center">
-              Category Search: {selectedCategory}, click to dismiss.
-            </p>
+            <div
+              onClick={() => {
+                window.location.replace(`/`);
+              }}
+              className="fixed top-5 p-1 px-3 z-[100] bg-indigo-500 cursor-pointer rounded-full"
+            >
+              <p className="text-white text-sm text-center">
+                Category Search: {selectedCategory}, click to dismiss.
+              </p>
+            </div>
           </div>
-        </div>
 
-        <div className="fixed bg-black z-[100] flex justify-center bottom-0 left-[50%] right-[50%] mb-5">
-          <Dock
-            items={items}
-            panelHeight={68}
-            baseItemSize={50}
-            magnification={70}
-          />
-        </div>
+          <div className="fixed bg-black z-[100] flex justify-center bottom-0 left-[50%] right-[50%] mb-5">
+            <Dock
+              items={items}
+              panelHeight={68}
+              baseItemSize={50}
+              magnification={70}
+            />
+          </div>
 
-        <div className="flex justify-center items-center h-[35em] bg-gray-100 relative">
-          <Suspense>
-            <Map />
-          </Suspense>
-        </div>
+          <div className="flex justify-center items-center h-[35em] bg-gray-100 relative">
+            <Suspense>
+              <Map />
+            </Suspense>
+          </div>
 
-        <div>
+          <div>
           <div className="sticky bg-white top-0 z-[99] py-15 animate-fade-up animate-ease-in-out px-10">
             <p className="text-center font-bold text-3xl lg:text-5xl">
               Find and Share Your Destinations
@@ -262,6 +435,7 @@ export default function Home() {
               {topCategories.map((item) => {
                 return (
                   <div
+                    data-animate="category-card"
                     onClick={() => {
                       setCurrentCategory(item.category);
                       window.location.replace(`/?category=${item.category}`);
@@ -382,25 +556,40 @@ export default function Home() {
           </div>
         </div>
 
-        <div className="mb-[5em] relative z-[80] mt-10 px-10">
+        <div
+          data-animate="feature-section"
+          className="mb-[5em] relative z-[80] mt-10 px-10"
+        >
           <div className="flex justify-center items-center mb-5">
             {" "}
             <img className="w-5" src={"/features.svg"}></img>
-            <p className="ml-1 text-center text-gray-600 font-semibold">
+            <p
+              data-animate="feature-header"
+              className="ml-1 text-center text-gray-600 font-semibold"
+            >
               OUR FEATURES
             </p>
           </div>
-          <p className="text-center text-4xl font-semibold">
+          <p
+            data-animate="feature-header"
+            className="text-center text-4xl font-semibold"
+          >
             A better way to share, and a better place to find.
           </p>
-          <p className="mt-10 text-gray-600 text-center">
+          <p
+            data-animate="feature-header"
+            className="mt-10 text-gray-600 text-center"
+          >
             No more boredom in Hong Kong after using this platform
           </p>
         </div>
 
         <div className="2xl:grid grid-cols-8 gap-5 md:px-10 lg:px-20 relative z-[80]">
           <div className="p-4 col-span-3">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -423,7 +612,10 @@ export default function Home() {
           </div>
 
           <div className="p-4 col-span-3">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -443,7 +635,10 @@ export default function Home() {
           </div>
 
           <div className="p-4 col-span-2">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -464,7 +659,10 @@ export default function Home() {
 
         <div className="2xl:grid grid-cols-6 gap-5 md:px-10 lg:px-20">
           <div className="p-4 col-span-2">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -482,7 +680,10 @@ export default function Home() {
             </div>
           </div>
           <div className="p-4 col-span-4">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -508,7 +709,10 @@ export default function Home() {
 
         <div className="2xl:grid grid-cols-2 gap-5 md:px-10 lg:px-20">
           <div className="p-4 col-span-1">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -528,7 +732,10 @@ export default function Home() {
             </div>
           </div>
           <div className="p-4 col-span-1">
-            <div className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6">
+            <div
+              data-animate="sketch-card"
+              className="border-2 rounded-xl p-10 border-gray-200 outline-gray-100 outline-6 overflow-hidden relative"
+            >
               <div
                 className="w-full h-[20em] rounded-xl"
                 style={{
@@ -551,7 +758,7 @@ export default function Home() {
 
         <div className="relative z-[50] px-10 2xl:px-20 mt-[20em]">
           <div className="lg:flex justify-between items-center">
-            <div>
+            <div data-animate="why-text">
               <div className="flex items-center mb-5">
                 {" "}
                 <img className="w-5" src={"/purpose.svg"}></img>
@@ -590,8 +797,14 @@ export default function Home() {
           </div>
         </div>
 
-        <div className="mt-[20em] px-3 md:px-10">
-          <div className="flex justify-center items-center mb-5">
+        <div
+          data-animate="team-section"
+          className="mt-[20em] px-3 md:px-10"
+        >
+          <div
+            data-animate="team-header"
+            className="flex justify-center items-center mb-5"
+          >
             {" "}
             <img className="w-5" src={"/team.svg"}></img>
             <p className="ml-1 text-center text-gray-600 font-semibold">
@@ -599,18 +812,27 @@ export default function Home() {
             </p>
           </div>
           <div className="flex justify-center mt-10">
-            <p className="text-center text-3xl lg:text-5xl w-[20em] leading-tight font-semibold">
+            <p
+              data-animate="team-header"
+              className="text-center text-3xl lg:text-5xl w-[20em] leading-tight font-semibold"
+            >
               Developed by Four Aspiring Talented Youth in Hong Kong
             </p>
           </div>
           <div className="flex justify-center">
-            <p className="text-center mt-5 text-gray-600">
+            <p
+              data-animate="team-header"
+              className="text-center mt-5 text-gray-600"
+            >
               The platform is built by a group of Gen Zs
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 2xl:grid-cols-4 gap-5 md:px-10 2xl:px-20 mt-20">
-            <div className="border-[.1em] p-5 h-[40em]">
+            <div
+              data-animate="team-card"
+              className="border-[.1em] p-5 h-[40em]"
+            >
               <div
                 className="w-full h-[25em] bg-center bg-cover"
                 style={{ backgroundImage: "url('/ricky.png')" }}
@@ -631,7 +853,10 @@ export default function Home() {
               </p>
             </div>
 
-            <div className="border-[.1em] p-5 h-[40em]">
+            <div
+              data-animate="team-card"
+              className="border-[.1em] p-5 h-[40em]"
+            >
               <div
                 className="w-full h-[25em] bg-center bg-contain bg-no-repeat"
                 style={{ backgroundImage: "url('/owenisas.png')" }}
@@ -652,7 +877,10 @@ export default function Home() {
               </p>
             </div>
 
-            <div className="border-[.1em] p-5 h-[40em]">
+            <div
+              data-animate="team-card"
+              className="border-[.1em] p-5 h-[40em]"
+            >
               <div
                 className="w-full h-[25em] bg-center bg-cover"
                 style={{ backgroundImage: "url('/jeff.png')" }}
@@ -675,7 +903,10 @@ export default function Home() {
               </p>
             </div>
 
-            <div className="border-[.1em] p-5 h-[40em]">
+            <div
+              data-animate="team-card"
+              className="border-[.1em] p-5 h-[40em]"
+            >
               <div
                 className="w-full h-[25em] bg-center bg-cover"
                 style={{ backgroundImage: "url('/chm.png')" }}
@@ -710,11 +941,21 @@ export default function Home() {
 
           <div className="flex justify-center relative z-[50] text-white items-center">
             <div className="mt-[14em]">
-              <p className="text-center text-3xl lg:text-5xl font-semibold">
-                Learn About Our Ideas and Initiatives
-              </p>
+              <SplitText
+                text="Learn About Our Ideas and Initiatives"
+                tag="p"
+                className="text-center text-3xl lg:text-5xl font-semibold"
+                splitType="words"
+                delay={180}
+                duration={0.6}
+                from={{ opacity: 0, y: 30 }}
+                to={{ opacity: 1, y: 0 }}
+                once={false}
+                textAlign="center"
+              />
               <div className="flex justify-center mt-10">
                 <Link
+                  data-animate="ideas-button"
                   className="bg-white p-5 px-20 text-black hover:px-30 duration-300 rounded-xl"
                   target="_blank"
                   href="https://devpost.com/software/hktap"
@@ -751,6 +992,7 @@ export default function Home() {
             isOpen={chatOpen}
             onToggle={() => setChatOpen(!chatOpen)}
           />
+        </div>
         </div>
       </Suspense>
     </>


### PR DESCRIPTION
## Summary
- orchestrated GSAP scroll-triggered animations for category tiles, feature headers, feature cards, the Why HKTAP copy, and team content so sections pop, slide, or wipe into view and reset when scrolling back
- wired the “Learn About Our Ideas and Initiatives” hero text through SplitText for word-by-word reveals and faded in the CTA button on scroll
- extended the SplitText component with a configurable `once` flag so text animations can replay when scrolling back up

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2bc914fb88321a5fb4f1983b9961d